### PR TITLE
Renew Certificate earlier

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -53,7 +53,7 @@ while true; do
       days_to_expire=$(((end_epoch - now_epoch) / 86400))
     fi
 
-    if [ "$days_to_expire" -lt 7 ]; then
+    if [ "$days_to_expire" -lt 30 ]; then
       # Get certificate (allowed to fail)
       certbot certonly -d "${domain}" -d "*.${domain}" --dns-cloudflare \
         --non-interactive --agree-tos --email "$EMAIL" || :


### PR DESCRIPTION
Renew the certicates that expire in less than 30 days give the
administrator more time to deal with errors.

This is the same interval than in `certbot renew`.

Signed-off-by: Sven Haardiek <sven.haardiek@iotec-gmbh.de>