### PR TITLE
Introduce Travis CI Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,11 @@
 sudo: false
-script:
-  - curl -fs https://raw.githubusercontent.com/lkiesow/automated-quay.io-deployment/master/deploy-on-quay | sh
+
+jobs:
+  include:
+    - stage: test
+      script:
+        - shellcheck *.sh
+    - stage: deploy
+      if: type != pull_request AND branch = master
+      script:
+        - curl -fs https://raw.githubusercontent.com/lkiesow/automated-quay.io-deployment/master/deploy-on-quay | sh


### PR DESCRIPTION
This patch adds shellcheck to the default Travis tests which are run on
all branches and pull requests while limiting the distribution step to
builds from the `master` branch only.

This fixes #9