### PR TITLE
Fix prerequisites

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apk --no-cache add \
    openssl \
    openssl-dev \
    python3 \
-   python3-dev
+   python3-dev \
+   py3-pip
 RUN pip3 install --no-cache-dir --upgrade pip \
    && pip3 install --no-cache-dir \
       certbot \


### PR DESCRIPTION
Seems like alpine's `pip3` is now part of the `py3-pip` package.